### PR TITLE
Author initials failsafe and override

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,29 @@ Check the [Wiki](https://github.com/art1fa/minimalX/wiki).
 
 I wrote an [example article](http://fabianbloggt.de/minimalx-article-format.html) to show you how minimalX renders your articles. There are also some additional styling methods explained.
 
+#### Configuration
+
+You can tweak how minimalX detects initials from the author name.
+
+By default, minimalX will use a space character to delimit the author's name,
+and extract initials from the first two tokens, e.g.:
+
+    AUTHOR = "John Doe" # initials are "JD"
+
+However, you can manually override this behavior by specifying the
+`AUTHOR_INITIALS_OVERRIDE` variable in your Pelican configuration file, as a
+dictionary that maps author names to initials, e.g.:
+
+    AUTHOR_INITIALS_OVERRIDE = {
+        "Jane Doe": "DJ",
+    }
+
+    AUTHOR "Jane Doe" # initials = "DJ"
+
+If minimalX fails to find any viable initials (for example, the author name
+does not contain any spaces and is not overridden in the configuration file),
+then it will default to using just the first character of the `AUTHOR` string.
+
 ### Contributions welcome!
 
 This theme is far from perfect, so I'm going to further improve it. If you like this theme, don't hestitate to submit issues and pull requests - I'd love to get in touch with you all ;)

--- a/README.md
+++ b/README.md
@@ -49,14 +49,16 @@ However, you can manually override this behavior by specifying the
 dictionary that maps author names to initials, e.g.:
 
     AUTHOR_INITIALS_OVERRIDE = {
-        "Jane Doe": "DJ",
+        "Jane Doe": "JH",
     }
 
-    AUTHOR "Jane Doe" # initials = "DJ"
+    AUTHOR = "Jane Doe" # initials = "DJ"
 
 If minimalX fails to find any viable initials (for example, the author name
 does not contain any spaces and is not overridden in the configuration file),
-then it will default to using just the first character of the `AUTHOR` string.
+then it will default to just the first character of the `AUTHOR` string, e.g.:
+
+    AUTHOR = "J-Doe" # initials = "J"
 
 ### Contributions welcome!
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ and extract initials from the first two tokens, e.g.:
 
     AUTHOR = "John Doe" # initials are "JD"
 
-However, you can manually override this behavior by specifying the
-`AUTHOR_INITIALS_OVERRIDE` variable in your Pelican configuration file, as a
-dictionary that maps author names to initials, e.g.:
+However, you can override this behavior by specifying the `AUTHOR_INITIALS`
+variable in your Pelican configuration file, as a dictionary that maps author
+names to initials, e.g.:
 
-    AUTHOR_INITIALS_OVERRIDE = {
+    AUTHOR_INITIALS = {
         "Jane Doe": "JH",
     }
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ dictionary that maps author names to initials, e.g.:
         "Jane Doe": "JH",
     }
 
-    AUTHOR = "Jane Doe" # initials = "DJ"
+    AUTHOR = "Jane Doe" # initials = "JH"
 
 If minimalX fails to find any viable initials (for example, the author name
 does not contain any spaces and is not overridden in the configuration file),

--- a/templates/base.html
+++ b/templates/base.html
@@ -58,7 +58,15 @@
   <div class="w3-row w3-card w3-white">
     <header id=banner>
        <!-- AUTHOR INITIALS-->
-      <a href="{{ SITEURL }}" id=logo title="Home">{{ AUTHOR[0] + AUTHOR[AUTHOR.index(" ")+1] }}</a>
+      <a href="{{ SITEURL }}" id=logo title="Home">
+        {% if AUTHOR_INITIALS is defined and AUTHOR in AUTHOR_INITIALS %}
+          {{ AUTHOR_INITIALS[AUTHOR] }}
+        {% elif " " in AUTHOR %}
+          {{ AUTHOR[0] + AUTHOR[AUTHOR.index(" ")+1] }}
+        {% else %}
+          {{ AUTHOR[0] }} 
+        {% endif %}
+      </a>
       <nav id="menu">
         <ul>
           {% if DISPLAY_PAGES_ON_MENU %}


### PR DESCRIPTION
Addressing this issue: #10 

```
{{ AUTHOR[0] + AUTHOR[AUTHOR.index(" ")+1] }}
```

Building shouldn't fail just because an author's name doesn't have a space in it. Some people might not have spaces in names, and others may have more complex names they would like to manually specify custom initials for. Introduces two small features:

- If no space exists in `AUTHOR`, just use leading character (assumed to be present)
- Can manually override initials using the `AUTHOR_INITIALS` variable and specifying a dict of names => initials in configuration file

See updated `README.md` for usage.